### PR TITLE
Typedef

### DIFF
--- a/typedef/prolog/typedef.pl
+++ b/typedef/prolog/typedef.pl
@@ -112,7 +112,7 @@ current_type(Type) :-
 current_type_constructor(Type, Constructor) :-
     user_type_constructor(Type, Constructor).
 
-user:term_expansion(:- type(Decl), Clauses) :-
+system:term_expansion(:- type(Decl), Clauses) :-
    wants_typedef,
    (  expand_type_declaration(Decl, Clauses) -> true
    ;  throw(error(bad_type_declaration(Decl), (type)/1))

--- a/typedef/prolog/typedef.pl
+++ b/typedef/prolog/typedef.pl
@@ -54,6 +54,7 @@
 */
 
 :- multifile user_type_syn/2, user_type_def/1, user_type_constructor/2.
+:- multifile error:has_type/2.
 :- op(1150,fx,type).
 :- op(1130,xfx, --->).
 


### PR DESCRIPTION
Fixes to make the typedef pack work when loaded before library(error) and installed inside the Prolog home.