### PR TITLE
Add sparkle support for goal expansion

### DIFF
--- a/sparkle/README
+++ b/sparkle/README
@@ -33,6 +33,40 @@ queries can be written to the right of it without parentheses.
 ?- dbp ?? rdf(A,rdf:type,dbont:'Photographer'); rdf(A, rdf:type, dbont:'MusicalArtist').
 ==
 
+
+---++++ Clause expansion
+
+If the following clause is defined:
+
+==
+cls(Class) :-
+        rdf(Class,rdf:type,owl:'Class').
+==
+
+Then cls/1 can be used in queries, e.g.
+
+==
+?-  dbp ?? cls(X).
+==
+
+The cls/1 goal will be expanded.
+
+More complex goals can be defined; for example, this queries for existential restrictions:
+
+==
+subclass_of(C,D) :- rdf(C,rdfs:subClassOf,Restr).
+svf_edge(C,P,D) :-
+        subclass_of(C,Restr),
+        rdf(Restr,owl:onProperty,P),
+        rdf(Restr,owl:someValuesFrom,D).
+==
+
+Only a subset of prolog can be expanded in this way. Conjunction,
+disjunction (or multiple clauses), negation are supported. Terminals
+rdf/3, rdf/4, and some predicates from the rdfs library are
+supported. In future a wider set of constructs may be supported,
+e.g. setof/3.
+
 ---++++ Change log
 
 	0.0.8: concurrent_or/3 moved to separate module, fixes to concurrent_or/3.

--- a/sparkle/prolog/sparql_dcg.pl
+++ b/sparkle/prolog/sparql_dcg.pl
@@ -137,9 +137,11 @@ goal(conj(GS)) --> seqmap_with_sep(" , ",goal,GS).
 goal(rdf(S,P,O)) -->
    { rdf_global_object(O,OO) },
    resource(S), " ",
-   resource(P), " ",
+   property(P), " ",
    object(OO).
 
+goal(rdf(S,P,O,G)) --> "GRAPH ", resource(G), brace(goal(rdf(S,P,O))).
+    
 goal(filter(Cond)) --> "FILTER ", cond(Cond).
 
 :- op(1150,fx,p).
@@ -176,6 +178,17 @@ expr(X*Y) --> p expr(X), " * ", expr(Y).
 expr(X/Y) --> p expr(X), " / ", expr(Y).
 expr(X) --> {number(X)}, at(X).
 expr(X) --> object(X).
+
+% https://www.w3.org/TR/sparql11-query/#pp-language
+property(oneOrMore(R)) --> resource(R),"+".
+property(zeroOrMore(R)) --> resource(R),"*".
+property(zeroOrOne(R)) --> resource(R),"?".
+property(inverse(R)) --> "^", resource(R).
+property(\+R) --> "!(", resource(R), ")".
+property(R1/R2) --> "(",resource(R1),"/",resource(R2),")".
+property(R1|R2) --> "(",resource(R1),"|",resource(R2),")".
+
+property(R) --> resource(R).
 
 resource(R) --> variable(R).
 resource(R) --> {rdf_global_id(R,RR)}, uri(RR).


### PR DESCRIPTION
Extended sparkle to include support for

 - expansion of goals on RHS of ??/2
 - support for rdf/4

Added docs to README describing this

Also: fixed bug in sparql_endpoint/3
Previously it was impossible for the assert to be called, as
the initial sparql_endpoint/5 would fail, causing the entire goal to
fail.