### PR TITLE
Fix escaping of double quotes

### DIFF
--- a/sparkle/prolog/sparql_dcg.pl
+++ b/sparkle/prolog/sparql_dcg.pl
@@ -188,7 +188,7 @@ literal(type(Type,Val)) --> quote(wr(Val)), "^^", resource(Type).
 literal(Lit) --> {atomic(Lit)}, quote(at(Lit)).
 
 uri(U) --> {atom(U)}, "<", at(U), ">".
-quote(P) --> "\"", escape_with(0'",0'\\,P), "\"".
+quote(P) --> "\"", escape_with(0'\\,0'",P), "\"".
 variable(V)  --> {var_number(V,N)}, "?v", at(N).
 variable(@V) --> "_:", {atomic(V) -> N=V; var_number(V,N)}, at(N).
 variable(@)  --> "[]".


### PR DESCRIPTION
escape_with takes the escape code as first argument and then the code to be escaped as second argument